### PR TITLE
Add optional model parameter to CacheRegistry.register method

### DIFF
--- a/rest_framework_cache/registry.py
+++ b/rest_framework_cache/registry.py
@@ -13,14 +13,15 @@ class CacheRegistry:
     def __init__(self):
         self._registry = {}
 
-    def register(self, serializer):
+    def register(self, serializer, model=None):
         """Store the serializer and model on registry to that the cache can be
         cleaned whenever an object is changed or deleted.
         After the serializer is registered we must connect the signals that
         clear the instance cache.
         can be used as a decorator
         """
-        model = serializer.Meta.model
+        if model is None:
+            model = serializer.Meta.model
 
         if model not in self._registry:
             self._registry[model] = []


### PR DESCRIPTION
Hi, we have the problem in our code that we use nested serializers quite often, but still have a very cacheable-setup. So I would like to be able to invalidate a serializer not only for the model that is defined in the `Meta` options.

I propose the simple change given in this PR.

Would you be willing to merge such a change? I'm happy to write any tests and whats necessary to finish the task. I just wanted to get your opinion before I invest more into it :)